### PR TITLE
Preload the coupons too

### DIFF
--- a/shuup/campaigns/models/campaigns.py
+++ b/shuup/campaigns/models/campaigns.py
@@ -272,7 +272,8 @@ class BasketCampaign(Campaign):
         queryset = cls.objects.filter(active=True, shop=basket.shop)
         if exclude_condition_ids:
             queryset = queryset.exclude(conditions__id__in=exclude_condition_ids)
-        for campaign in queryset.prefetch_related("conditions"):
+
+        for campaign in queryset.prefetch_related("conditions").select_related("coupon"):
             if campaign.rules_match(basket, lines):
                 matching.append(campaign)
         return matching


### PR DESCRIPTION
We were pre-fetching the campaign conditions but not the coupons. This MR is to avoid making N+1 queries where N is the number of active campaigns in the current shop.

Also, it would be great if I could be added to unu team :)

@mertcetin 